### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-datafactory
+  name: terraform-az-overlays-datafactory
   description: Terraform overlay module for Azure Data Factory
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-datafactory
+    github.com/project-slug: POps-Rox/terraform-az-overlays-datafactory
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-datafactory
+    - url: https://github.com/POps-Rox/terraform-az-overlays-datafactory
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commercial/basic_existing_rg_azure_runtime/dependencies.tf
+++ b/examples/Commercial/basic_existing_rg_azure_runtime/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }

--- a/examples/Commercial/basic_existing_rg_azure_runtime/main.tf
+++ b/examples/Commercial/basic_existing_rg_azure_runtime/main.tf
@@ -3,7 +3,7 @@
 
 
 module "data_factory" {
-  #source = "github.com/POps-Rox/tf-az-overlays-datafactory"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-datafactory"  
   #version = "x.x.x"  
   source = "../../.."
 

--- a/examples/Commercial/basic_existing_rg_selfhosted_runtime/dependencies.tf
+++ b/examples/Commercial/basic_existing_rg_selfhosted_runtime/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }

--- a/examples/Commercial/basic_existing_rg_selfhosted_runtime/main.tf
+++ b/examples/Commercial/basic_existing_rg_selfhosted_runtime/main.tf
@@ -3,7 +3,7 @@
 
 
 module "data_factory" {
-  #source = "github.com/POps-Rox/tf-az-overlays-datafactory"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-datafactory"  
   #version = "x.x.x"  
   source = "../../.."
 

--- a/examples/Government/basic_existing_rg_azure_runtime/dependencies.tf
+++ b/examples/Government/basic_existing_rg_azure_runtime/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }

--- a/examples/Government/basic_existing_rg_azure_runtime/main.tf
+++ b/examples/Government/basic_existing_rg_azure_runtime/main.tf
@@ -3,7 +3,7 @@
 
 
 module "data_factory" {
-  #source = "github.com/POps-Rox/tf-az-overlays-datafactory"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-datafactory"  
   #version = "x.x.x"  
   source = "../../.."
 

--- a/examples/Government/basic_existing_rg_selfhosted_runtime/dependencies.tf
+++ b/examples/Government/basic_existing_rg_selfhosted_runtime/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }

--- a/examples/Government/basic_existing_rg_selfhosted_runtime/main.tf
+++ b/examples/Government/basic_existing_rg_selfhosted_runtime/main.tf
@@ -3,7 +3,7 @@
 
 
 module "data_factory" {
-  #source = "github.com/POps-Rox/tf-az-overlays-datafactory"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-datafactory"  
   #version = "x.x.x"  
   source = "../../.."
 

--- a/module.data.factory.scaffolding.tf
+++ b/module.data.factory.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_data_factory_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.